### PR TITLE
Suggest fmt fixes where possibe

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"strings"
 
 	"gopkg.in/src-d/lookout-sdk.v0/pb"
 
@@ -83,11 +84,28 @@ func (a Analyzer) NotifyReviewEvent(ctx context.Context, review *pb.ReviewEvent)
 		formatted := hclwrite.Format(change.Head.Content)
 		// check if changes have been made
 		if !bytes.Equal(change.Head.Content, formatted) {
-			comments = append(comments, &pb.Comment{
-				File: change.Head.Path,
-				Line: 0,
-				Text: fmt.Sprintf("This file is not Terraform fmt'ed"),
-			})
+			oldLines := strings.Split(string(change.Head.Content), "\n")
+			newLines := strings.Split(string(formatted), "\n")
+			if len(oldLines) != len(newLines) {
+				// multi line changes are not fully supported by GitHub yet, falling back to a comment
+				comments = append(comments, &pb.Comment{
+					File: change.Head.Path,
+					Line: 0,
+					Text: fmt.Sprintf("This file is not Terraform fmt'ed"),
+				})
+				continue
+			}
+
+			for i := range oldLines {
+				if oldLines[i] != newLines[i] {
+					comments = append(comments, &pb.Comment{
+						File: change.Head.Path,
+						Line: int32(i + 1),
+						Text: fmt.Sprintf("```suggestion\n%s\n```", newLines[i]),
+					})
+				}
+			}
+
 		}
 	}
 

--- a/analyzer.go
+++ b/analyzer.go
@@ -105,7 +105,6 @@ func (a Analyzer) NotifyReviewEvent(ctx context.Context, review *pb.ReviewEvent)
 					})
 				}
 			}
-
 		}
 	}
 


### PR DESCRIPTION
This change will let the analyzer submit suggestion comments in case
where this is possible. Meaning then the fmt suggestion doesn't add newlines.

Signed-off-by: Maartje Eyskens <maartje@eyskens.me>